### PR TITLE
metadata: Mark as compatible with gnome shell 3.8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,8 @@
     "3.2", "3.2.1",
     "3.3.90", "3.3.91", "3.3.92", "3.3.93", "3.3.94",
     "3.4", "3.4.1",
-    "3.6"
+    "3.6",
+    "3.8"
   ],
   "url": "https://github.com/bonzini/gnome-shell-permanent-notifications",
   "uuid": "permanent-notifications@bonzini.gnu.org",


### PR DESCRIPTION
Works fine for me here on 3.8.1
