### PR TITLE
Update for Gnome 45

### DIFF
--- a/permanent-notifications@bonzini.gnu.org/extension.js
+++ b/permanent-notifications@bonzini.gnu.org/extension.js
@@ -1,19 +1,24 @@
 /* -*- mode: js2; js2-basic-offset: 4; indent-tabs-mode: nil -*- */
 
-const MessageTray = imports.ui.messageTray;
+import { Extension } from "resource:///org/gnome/shell/extensions/extension.js";
+import * as MessageTray from "resource:///org/gnome/shell/ui/messageTray.js";
 
-function init() {
-    let tray = MessageTray.MessageTray.prototype;
-    tray.oldUpdateNotificationTimeout = tray._updateNotificationTimeout;
-}
+export default class PermanentNotificationExtension extends Extension {
+    constructor(metadata) {
+        super(metadata);
 
-function enable() {
-    MessageTray.MessageTray.prototype._updateNotificationTimeout = function(timeout) {
-        this._notificationTimeoutId = timeout ? 1 : 0;
+        let tray = MessageTray.MessageTray.prototype;
+        tray.oldUpdateNotificationTimeout = tray._updateNotificationTimeout;
     }
-}
 
-function disable() {
-    let tray = MessageTray.MessageTray.prototype;
-    tray._updateNotificationTimeout = tray.oldUpdateNotificationTimeout;
+    enable() {
+        MessageTray.MessageTray.prototype._updateNotificationTimeout = function(timeout) {
+            this._notificationTimeoutId = timeout ? 1 : 0;
+        };
+    }
+
+    disable() {
+        let tray = MessageTray.MessageTray.prototype;
+        tray._updateNotificationTimeout = tray.oldUpdateNotificationTimeout;
+    }
 }

--- a/permanent-notifications@bonzini.gnu.org/metadata.json
+++ b/permanent-notifications@bonzini.gnu.org/metadata.json
@@ -7,16 +7,9 @@
     "bonzini@gnu.org"
   ],
   "shell-version": [
-    "3.2", "3.2.1",
-    "3.3.90", "3.3.91", "3.3.92", "3.3.93", "3.3.94",
-    "3.4", "3.4.1",
-    "3.6",
-    "3.8",
-    "3.10",
-    "40.0"
-
+    "45"
   ],
   "url": "https://github.com/bonzini/gnome-shell-permanent-notifications",
   "uuid": "permanent-notifications@bonzini.gnu.org",
-  "version": 5
+  "version": 6
 }


### PR DESCRIPTION
This PR updates the extension for Gnome 45, following the guidelines in https://gjs.guide/extensions/upgrading/gnome-shell-45.html and https://gjs.guide/extensions/overview/anatomy.html

Note that after the update, this version will only work for Gnome 45+, and not earlier versions.